### PR TITLE
Implement lazy loading of thumbnail images

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,7 @@
     <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="js/dialog-polyfill.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.10/jquery.lazy.min.js"></script>
     <script src="js/LQA.js"></script>
     <script src="js/toscan.js"></script>
   </body>

--- a/docs/js/LQA.js
+++ b/docs/js/LQA.js
@@ -34,7 +34,7 @@ function initscan(toscan) {
         var list = toscan[band];
         for(var i = 0; i < list.length; i++) {
             var div = $('<div>').addClass('thumb');
-            div.append($('<img>', {src: IMGSRC + list[i] + '.jpg'}));
+            div.append($('<img>', {'data-src': IMGSRC + list[i] + '.jpg', 'src': ""}));
             var tag = list[i].slice(6);
             div.append($('<span>').addClass('qa-button topleft').attr('id', 'Q_' + tag).html('?'));
             div.append($('<span>').addClass('qa-button btmleft').attr('id', 'X_' + tag).html('&cross;'));

--- a/docs/js/LQA.js
+++ b/docs/js/LQA.js
@@ -34,7 +34,7 @@ function initscan(toscan) {
         var list = toscan[band];
         for(var i = 0; i < list.length; i++) {
             var div = $('<div>').addClass('thumb');
-            div.append($('<img>', {'data-src': IMGSRC + list[i] + '.jpg', 'src': ""}));
+            div.append($('<img>', {'data-src': IMGSRC + list[i] + '.jpg', src: "", class: 'lazy'}));
             var tag = list[i].slice(6);
             div.append($('<span>').addClass('qa-button topleft').attr('id', 'Q_' + tag).html('?'));
             div.append($('<span>').addClass('qa-button btmleft').attr('id', 'X_' + tag).html('&cross;'));
@@ -90,4 +90,6 @@ function initscan(toscan) {
         var img = $(this).parent().siblings('.mdl-dialog__content').children('img').attr('src');
         window.open(img, '_blank');
     });
+    // Enable lazy image loading.
+    $('img.lazy').Lazy({scrollDirection: 'vertical'});
 }

--- a/docs/js/LQA.js
+++ b/docs/js/LQA.js
@@ -50,6 +50,9 @@ function initscan(toscan) {
     // Add handler for QA buttons.
     $('.qa-button').click(function() {
         var tag = $(this).attr('id');
+        // Do nothing if this image has not been loaded yet.
+        var src = $(this).siblings('img').attr('src');
+        if(src == '') return;
         var selected = $(this).hasClass('selected');
         if(selected) {
             $(this).removeClass('selected');
@@ -73,7 +76,9 @@ function initscan(toscan) {
     $('.details-button').click(function() {
         var tag = $(this).attr('id');
         $('#details-title').text(tag);
+        // Do nothing if this image has not been loaded yet.
         var src = $(this).siblings('img').attr('src');
+        if(src == '') return;
         $('#details-content img').attr('src', src);
         dialog.showModal();
     });


### PR DESCRIPTION
Fixes #3.

Uses https://github.com/eisbehr-/jquery.lazy to do most of the work (loaded from a CDN).

Buttons are disabled until an image loads.

Tested on a client running locally (with 500 images per band) but cannot test via dkirkby.github.io/legacyQA until this is merged into master.

I think this solves the browser latency issue, but will still require the browser DOM to hold ~6K small jpg images totaling ~800Mb.  Is this a problem?  I am using the quality defaults of [plt.imsave](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.imsave.html), so there may be something to gain there.